### PR TITLE
scene and graphic centering implementation

### DIFF
--- a/fastplotlib/layouts.py
+++ b/fastplotlib/layouts.py
@@ -1,5 +1,4 @@
 from itertools import product
-from functools import partial
 import numpy as np
 import pygfx
 from .defaults import camera_types, controller_types
@@ -139,6 +138,10 @@ class GridPlot:
 
     def show(self):
         self.canvas.request_draw(self.animate)
+
+        for subplot in self:
+            subplot.center_scene()
+
         return self.canvas
 
     def _get_iterator(self):

--- a/fastplotlib/plot.py
+++ b/fastplotlib/plot.py
@@ -1,5 +1,4 @@
 import pygfx
-from pygfx.linalg import Vector3
 from wgpu.gui.auto import WgpuCanvas
 from .subplot import Subplot
 from . import graphics
@@ -46,4 +45,6 @@ class Plot(Subplot):
 
     def show(self):
         self.canvas.request_draw(self.animate)
+        self.center_scene()
+
         return self.canvas

--- a/fastplotlib/subplot.py
+++ b/fastplotlib/subplot.py
@@ -66,7 +66,7 @@ class Subplot:
 
         w, h = self.renderer.logical_size
 
-        spacing = 0  # spacing in pixels
+        spacing = 2  # spacing in pixels
 
         self.viewport.rect = [
             ((w / self.ncols) + ((j - 1) * (w / self.ncols))) + spacing,
@@ -89,19 +89,38 @@ class Subplot:
         self.scene.add(graphic.world_object)
 
         if center:
-            self.center_scene()
+            self.center_graphic(graphic)
 
-    def center_graphic(self):
-        pass
+    def _refresh_camera(self):
+        self.controller.update_camera(self.camera)
+        if sum(self.renderer.logical_size) > 0:
+            scene_lsize = self.viewport.rect[2], self.viewport.rect[3]
+        else:
+            scene_lsize = (1, 1)
+
+        self.camera.set_view_size(*scene_lsize)
+        self.camera.update_projection_matrix()
+
+    def center_graphic(self, graphic, zoom: float = 1.3):
+        if not isinstance(self.camera, pygfx.OrthographicCamera):
+            warn("`center_graphic()` not yet implemented for `PerspectiveCamera`")
+            return
+
+        self._refresh_camera()
+
+        self.controller.show_object(self.camera, graphic.world_object)
+
+        self.controller.zoom(zoom)
 
     def center_scene(self, zoom: float = 1.3):
+        if not len(self.scene.children) > 0:
+            return
+
         if not isinstance(self.camera, pygfx.OrthographicCamera):
             warn("`center_scene()` not yet implemented for `PerspectiveCamera`")
             return
 
-        self.controller.update_camera(self.camera)
-        self.camera.set_view_size(1, 1)
-        self.camera.update_projection_matrix()
+        self._refresh_camera()
 
         self.controller.show_object(self.camera, self.scene)
 


### PR DESCRIPTION
`pygfx` just added a `show_object()` method for controllers so it was possible to implement methods to center the camera and controller according to the bounding box of a scene or graphic (WorldObject).

https://github.com/pygfx/pygfx/pull/326

This PR implements:
- `Subplot.center_scene()`
- `Subplot.center_graphic()`
- `Subplot._refresh_camera()`

Scene centering is also done for all subplots in a `GridPlot` when `show()` is called. Likewise for `Plot.show()`