### PR TITLE
fix bug where subplot will not add more than one graphic with None as name

### DIFF
--- a/fastplotlib/subplot.py
+++ b/fastplotlib/subplot.py
@@ -95,12 +95,14 @@ class Subplot:
         self._animate_funcs += funcs
 
     def add_graphic(self, graphic, center: bool = True):
-        graphic_names = list()
-        for g in self._graphics:
-            graphic_names.append(g.name)
+        if graphic.name is not None:  # skip for those that have no name
+            graphic_names = list()
 
-        if graphic.name in graphic_names:
-            raise ValueError(f"graphics must have unique names, current graphic names are:\n {graphic_names}")
+            for g in self._graphics:
+                graphic_names.append(g.name)
+
+            if graphic.name in graphic_names:
+                raise ValueError(f"graphics must have unique names, current graphic names are:\n {graphic_names}")
 
         self._graphics.append(graphic)
         self.scene.add(graphic.world_object)


### PR DESCRIPTION
@clewis7 fixes this issue which I didn't foresee, arises if multiple graphics with name `None` are added to the same subplot:

```python
File ~/repos/fastplotlib/fastplotlib/subplot.py:105, in Subplot.add_graphic(self, graphic, center)
    102     graphic_names.append(g.name)
    104 if graphic.name in graphic_names:
--> 105     raise ValueError(f"graphics must have unique names, current graphic names are:\n {graphic_names}")
    107 self._graphics.append(graphic)
    108 self.scene.add(graphic.world_object)

ValueError: graphics must have unique names, current graphic names are:
```