### PR TITLE
subplots can have titles now

### DIFF
--- a/fastplotlib/layouts/_subplot.py
+++ b/fastplotlib/layouts/_subplot.py
@@ -104,18 +104,18 @@ class Subplot(PlotArea):
             tg = TextGraphic(text)
             self._title_graphic = tg
 
-            self.docked_viewports["top"].size = 25
+            self.docked_viewports["top"].size = 35
             self.docked_viewports["top"].add_graphic(tg)
 
-            self._title_graphic.world_object.position.set(0, -2, 0)
+            self.center_title()
 
     def center_title(self):
         if self._title_graphic is None:
             raise AttributeError("No title graphic is set")
 
         self._title_graphic.world_object.position.set(0, 0, 0)
-        self.docked_viewports["top"].center_graphic(self._title_graphic)
-        self._title_graphic.world_object.position.y = -2
+        self.docked_viewports["top"].center_graphic(self._title_graphic, zoom=1.5)
+        self._title_graphic.world_object.position.y = -3.5
 
     def get_rect(self):
         row_ix, col_ix = self.position

--- a/fastplotlib/widgets/image.py
+++ b/fastplotlib/widgets/image.py
@@ -513,7 +513,7 @@ class ImageWidget:
                         min=minmax[0] - data_range_30p,
                         max=minmax[1] + data_range_30p,
                         step=data_range / 150,
-                        description=f"mm ['{name_slider}']",
+                        description=f"mm: {name_slider}",
                         readout=True,
                         readout_format='.3f',
                     )
@@ -535,6 +535,7 @@ class ImageWidget:
                 ig = ImageGraphic(frame, **_kwargs)
                 subplot.add_graphic(ig)
                 subplot.name = name
+                subplot.set_title(name)
                 self.image_graphics.append(ig)
 
         self.plot.renderer.add_event_handler(self._set_slider_layout, "resize")


### PR DESCRIPTION
`TextGraphic` is placed in the top docked viewport of the `Subplot`, positioning is a bit wonky right now.

really useful for `mesmerize-core`, example

```python3
# first item is just the raw movie
mcorr_outputs = [df.iloc[0].caiman.get_input_movie()]
subplot_names = ["raw"]

# add all the mcorr outputs to the list
for i, r in df.iterrows():
    if i > 4:
        break
    mcorr_outputs.append(r.mcorr.get_output())
    subplot_names.append(f"ix: {i}")

mcorr_iw = ImageWidget(
    data=mcorr_outputs, 
    vmin_vmax_sliders=True,
    names=subplot_names,
    cmap="gnuplot2"
)
mcorr_iw.show()
```

![image](https://user-images.githubusercontent.com/9403332/208293408-8c249b21-4a6f-4b42-9bbe-fb0c56f21003.png)
