### PR TITLE
More interaction

### DIFF
--- a/fastplotlib/graphics/features/_base.py
+++ b/fastplotlib/graphics/features/_base.py
@@ -107,8 +107,13 @@ class GraphicFeature(ABC):
 
         for func in self._event_handlers:
             try:
-                if len(getfullargspec(func).args) > 0:
-                    func(event_data)
+                args = getfullargspec(func).args
+
+                if len(args) > 0:
+                    if args[0] == "self" and not len(args) > 1:
+                        func()
+                    else:
+                        func(event_data)
                 else:
                     func()
             except:

--- a/fastplotlib/graphics/image.py
+++ b/fastplotlib/graphics/image.py
@@ -10,8 +10,9 @@ from ..utils import quick_min_max
 class ImageGraphic(Graphic, Interaction):
     feature_events = [
         "data",
-        "colors",
+        "cmap",
     ]
+
     def __init__(
             self,
             data: Any,

--- a/fastplotlib/graphics/line.py
+++ b/fastplotlib/graphics/line.py
@@ -11,6 +11,9 @@ class LineGraphic(Graphic, Interaction):
     feature_events = [
         "data",
         "colors",
+        "cmap",
+        "thickness",
+        "present"
     ]
 
     def __init__(


### PR DESCRIPTION
- bugfix for handling feature events if the event handlers are methods instead of functions
- bugfix, image has cmap and not colors for `feature_events` class attr
- `Graphic.link()` can be bidirectional using kwarg `bidirectional=True`
  - Basically if `bidirectional=True`, `Graphic.link()` does `target.link()` with the same arguments. `target.link()` uses `bidirectional=False` to prevent infinite recursion.
  - `_set_feature()` exits (just returns) if the `previous_data.indices` is identical to the new indices, this was also necessary to prevent infinite recurusion.
  - allow 1D numpy arrays for indexing `GraphicCollection`
