### PR TITLE
better buffer handling

### DIFF
--- a/fastplotlib/graphics/features/_base.py
+++ b/fastplotlib/graphics/features/_base.py
@@ -4,7 +4,7 @@ from warnings import warn
 from typing import *
 
 import numpy as np
-from pygfx import Buffer
+from pygfx import Buffer, Texture
 
 
 supported_dtypes = [
@@ -226,7 +226,7 @@ class GraphicFeatureIndexable(GraphicFeature):
 
     @property
     @abstractmethod
-    def _buffer(self) -> Buffer:
+    def buffer(self) -> Union[Buffer, Texture]:
         pass
 
     @property
@@ -238,21 +238,21 @@ class GraphicFeatureIndexable(GraphicFeature):
         key = cleanup_slice(key, self._upper_bound)
 
         if isinstance(key, int):
-            self._buffer.update_range(key, size=1)
+            self.buffer.update_range(key, size=1)
             return
 
         # else if it's a slice obj
         if isinstance(key, slice):
             if key.step == 1:  # we cleaned up the slice obj so step of None becomes 1
                 # update range according to size using the offset
-                self._buffer.update_range(offset=key.start, size=key.stop - key.start)
+                self.buffer.update_range(offset=key.start, size=key.stop - key.start)
 
             else:
                 step = key.step
                 # convert slice to indices
                 ixs = range(key.start, key.stop, step)
                 for ix in ixs:
-                    self._buffer.update_range(ix, size=1)
+                    self.buffer.update_range(ix, size=1)
         else:
             raise TypeError("must pass int or slice to update range")
 

--- a/fastplotlib/graphics/features/_colors.py
+++ b/fastplotlib/graphics/features/_colors.py
@@ -7,11 +7,11 @@ from pygfx import Color
 
 class ColorFeature(GraphicFeatureIndexable):
     @property
-    def _buffer(self):
+    def buffer(self):
         return self._parent.world_object.geometry.colors
 
     def __getitem__(self, item):
-        return self._buffer.data[item]
+        return self.buffer.data[item]
 
     def __init__(self, parent, colors, n_colors: int, alpha: float = 1.0, collection_index: int = None):
         """
@@ -113,7 +113,7 @@ class ColorFeature(GraphicFeatureIndexable):
                 raise ValueError("fancy indexing for colors must be 2-dimension, i.e. [n_datapoints, RGBA]")
 
             # set the user passed data directly
-            self._buffer.data[key] = value
+            self.buffer.data[key] = value
 
             # update range
             # first slice obj is going to be the indexing so use key[0]
@@ -162,7 +162,7 @@ class ColorFeature(GraphicFeatureIndexable):
             else:
                 raise ValueError("numpy array passed to color must be of shape (4,) or (n_colors_modify, 4)")
 
-        self._buffer.data[key] = new_colors
+        self.buffer.data[key] = new_colors
 
         self._update_range(key)
         self._feature_changed(key, new_colors)


### PR DESCRIPTION
- all feature buffers are now public
- `ImageGraphic` and `HeatmapGraphic` allow setting the input array buffer directly as the texture data buffer if `isolated_buffer=False`. The default is `True`, so by default the texture data buffer is a new array that is initialized using the shape and type of the input array, and then the isolated texture data buffer is set using the input data array values.

allows this type of behavior:
![image](https://user-images.githubusercontent.com/9403332/223941432-7a25fb7f-a4d1-48b0-b602-d98919a9157d.png)
