### PR TITLE
garbage collection of WorldObjects 

### DIFF
--- a/examples/garbage_collection.ipynb
+++ b/examples/garbage_collection.ipynb
@@ -72,26 +72,51 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "27627cd4-c363-4eab-a121-f6c8abbbe5ae",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "graphic = \"scatter\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d9c10edc-169a-4dd2-bd5b-8a1b67baf3a9",
+   "metadata": {},
+   "source": [
+    "### Run the following cells repeatedly to add and remove the graphic"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "e26d392f-6afd-4e89-a685-d618065d3caf",
    "metadata": {
     "tags": []
    },
    "outputs": [],
    "source": [
-    "# for line\n",
-    "# a = np.random.rand(10_000_000)\n",
+    "if graphic == \"line\":\n",
+    "    a = np.random.rand(10_000_000)\n",
+    "    g = plot.add_line(a)\n",
+    "    \n",
+    "elif graphic == \"heatmap\":\n",
+    "    a = np.random.rand(20_000, 20_000)\n",
+    "    g = plot.add_heatmap(a)\n",
     "\n",
-    "# for heatmap\n",
-    "# a = np.random.rand(20_000, 20_000)\n",
+    "elif graphic == \"line_collection\":\n",
+    "    a = np.random.rand(500, 50_000)\n",
+    "    g = plot.add_line_collection(a)\n",
+    "    \n",
+    "elif graphic == \"image\":\n",
+    "    a = np.random.rand(7_000, 7_000)\n",
+    "    g = plot.add_image(a)\n",
     "\n",
-    "# for line collection\n",
-    "# a = np.random.rand(500, 50_000)\n",
-    "\n",
-    "# for image\n",
-    "# a = np.random.rand(7_000, 7_000)\n",
-    "\n",
-    "# for scatter\n",
-    "a = np.random.rand(10_000_000, 3)"
+    "elif graphic == \"scatter\":\n",
+    "    a = np.random.rand(10_000_000, 3)\n",
+    "    g = plot.add_scatter(a)"
    ]
   },
   {
@@ -104,21 +129,6 @@
    "outputs": [],
    "source": [
     "print_process_ram_mb()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "9cf2ceaa-5b01-4e12-be39-f267cd355833",
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "# g = plot.add_line_collection(a)\n",
-    "# g = plot.add_heatmap(a)\n",
-    "# g = plot.add_line(a)\n",
-    "g = plot.add_scatter(a)"
    ]
   },
   {
@@ -167,6 +177,14 @@
    "outputs": [],
    "source": [
     "plot.delete_graphic(plot.graphics[0])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "47baa487-c66b-4c40-aa11-d819902870e3",
+   "metadata": {},
+   "source": [
+    "If there is no serious system memory leak, this value shouldn't really increase after repeated cycles"
    ]
   },
   {

--- a/examples/garbage_collection.ipynb
+++ b/examples/garbage_collection.ipynb
@@ -23,25 +23,37 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "1bb6bc6f-7786-4d23-9eb1-e30bbc66c798",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
-    "print(process.memory_info().rss / 1024 / 1024)"
+    "def print_process_ram_mb():\n",
+    "    print(process.memory_info().rss / 1024 / 1024)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b376676e-a7fe-4424-9ba6-fde5be03b649",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "print_process_ram_mb()"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "b23ba640-88ec-40d9-b53c-c8cbb3e39b0b",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "plot = Plot()\n",
-    "\n",
-    "# a = np.random.rand(5_000_000)\n",
-    "# plot.add_line(a)\n",
-    "\n",
-    "\n",
     "plot.show()"
    ]
   },
@@ -49,57 +61,85 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "17f46f21-b29d-4dd3-9496-989bbb240f50",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
-    "print(process.memory_info().rss / 1024 / 1024)"
+    "print_process_ram_mb()"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "e26d392f-6afd-4e89-a685-d618065d3caf",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
-    "a = np.random.rand(1_000, 5_000)"
+    "# for line\n",
+    "# a = np.random.rand(10_000_000)\n",
+    "\n",
+    "# for heatmap\n",
+    "# a = np.random.rand(20_000, 20_000)\n",
+    "\n",
+    "# for line collection\n",
+    "# a = np.random.rand(500, 50_000)\n",
+    "\n",
+    "# for image\n",
+    "# a = np.random.rand(7_000, 7_000)\n",
+    "\n",
+    "# for scatter\n",
+    "a = np.random.rand(10_000_000, 3)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "31e3027a-56cf-4f7b-ba78-aed4f78eef47",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
-    "print(process.memory_info().rss / 1024 / 1024)"
+    "print_process_ram_mb()"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "9cf2ceaa-5b01-4e12-be39-f267cd355833",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
-    "plot.add_line_stack(a)"
+    "# g = plot.add_line_collection(a)\n",
+    "# g = plot.add_heatmap(a)\n",
+    "# g = plot.add_line(a)\n",
+    "g = plot.add_scatter(a)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "53170858-ae72-4451-8647-7d5b1f9da75e",
-   "metadata": {},
+   "id": "6518795c-98cf-405d-94ab-786ac3b2e1d6",
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
-    "print(process.memory_info().rss / 1024 / 1024)"
+    "g"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "ee2481c9-82e3-4043-85fd-21a0cdf21187",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "plot.auto_scale()"
@@ -108,8 +148,22 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "53170858-ae72-4451-8647-7d5b1f9da75e",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "print(process.memory_info().rss / 1024 / 1024)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "e4e0f73b-c58a-40e7-acf5-07a1f70d2821",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "plot.delete_graphic(plot.graphics[0])"
@@ -119,7 +173,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "56c64498-229e-48b7-9fb1-f7c327fff2ae",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "print(process.memory_info().rss / 1024 / 1024)"

--- a/examples/garbage_collection.ipynb
+++ b/examples/garbage_collection.ipynb
@@ -1,0 +1,345 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1ef0578e-09e1-45ff-bd34-84472db3885e",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "from fastplotlib import Plot\n",
+    "import numpy as np\n",
+    "import sys\n",
+    "\n",
+    "import weakref\n",
+    "import gc\n",
+    "import os, psutil\n",
+    "process = psutil.Process(os.getpid())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1bb6bc6f-7786-4d23-9eb1-e30bbc66c798",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(process.memory_info().rss / 1024 / 1024)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b23ba640-88ec-40d9-b53c-c8cbb3e39b0b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot = Plot()\n",
+    "\n",
+    "# a = np.random.rand(5_000_000)\n",
+    "# plot.add_line(a)\n",
+    "\n",
+    "\n",
+    "plot.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "17f46f21-b29d-4dd3-9496-989bbb240f50",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(process.memory_info().rss / 1024 / 1024)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e26d392f-6afd-4e89-a685-d618065d3caf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "a = np.random.rand(1_000, 5_000)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "31e3027a-56cf-4f7b-ba78-aed4f78eef47",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(process.memory_info().rss / 1024 / 1024)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9cf2ceaa-5b01-4e12-be39-f267cd355833",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot.add_line_stack(a)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "53170858-ae72-4451-8647-7d5b1f9da75e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(process.memory_info().rss / 1024 / 1024)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ee2481c9-82e3-4043-85fd-21a0cdf21187",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot.auto_scale()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e4e0f73b-c58a-40e7-acf5-07a1f70d2821",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot.delete_graphic(plot.graphics[0])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "56c64498-229e-48b7-9fb1-f7c327fff2ae",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(process.memory_info().rss / 1024 / 1024)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dd6a26c1-ea81-469d-ae7a-95839b1f9d5a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "from wgpu.gui.auto import WgpuCanvas, run\n",
+    "import pygfx as gfx\n",
+    "import subprocess\n",
+    "\n",
+    "canvas = WgpuCanvas()\n",
+    "renderer = gfx.WgpuRenderer(canvas)\n",
+    "scene = gfx.Scene()\n",
+    "camera = gfx.OrthographicCamera(5000, 5000)\n",
+    "camera.position.x = 2048\n",
+    "camera.position.y = 2048\n",
+    "\n",
+    "\n",
+    "def make_image():\n",
+    "    data = np.random.rand(4096, 4096).astype(np.float32)\n",
+    "\n",
+    "    return gfx.Image(\n",
+    "        gfx.Geometry(grid=gfx.Texture(data, dim=2)),\n",
+    "        gfx.ImageBasicMaterial(clim=(0, 1)),\n",
+    "    )\n",
+    "\n",
+    "\n",
+    "class Graphic:\n",
+    "    def __init__(self):\n",
+    "        data = np.random.rand(4096, 4096).astype(np.float32)\n",
+    "        self.wo = gfx.Image(\n",
+    "        gfx.Geometry(grid=gfx.Texture(data, dim=2)),\n",
+    "        gfx.ImageBasicMaterial(clim=(0, 1)),\n",
+    "    )\n",
+    "\n",
+    "\n",
+    "def draw():\n",
+    "    renderer.render(scene, camera)\n",
+    "    canvas.request_draw()\n",
+    "\n",
+    "\n",
+    "def print_nvidia(msg):\n",
+    "    print(msg)\n",
+    "    print(\n",
+    "        subprocess.check_output([\"nvidia-smi\", \"--format=csv\", \"--query-gpu=memory.used\"]).decode().split(\"\\n\")[1]\n",
+    "    )\n",
+    "    print()\n",
+    "\n",
+    "\n",
+    "def add_img(*args):\n",
+    "    print_nvidia(\"Before creating image\")\n",
+    "    img = make_image()\n",
+    "    print_nvidia(\"After creating image\")\n",
+    "    scene.add(img)\n",
+    "    img.add_event_handler(remove_img, \"click\")\n",
+    "    draw()\n",
+    "    print_nvidia(\"After add image to scene\")\n",
+    "\n",
+    "\n",
+    "def remove_img(*args):\n",
+    "    img = scene.children[0]\n",
+    "    scene.remove(img)\n",
+    "    draw()\n",
+    "    print_nvidia(\"After remove image from scene\")\n",
+    "    del img\n",
+    "    draw()\n",
+    "    print_nvidia(\"After del image\")\n",
+    "\n",
+    "\n",
+    "renderer.add_event_handler(add_img, \"double_click\")\n",
+    "canvas"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2599f430-8b00-4490-9e11-774897be6e77",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "from wgpu.gui.auto import WgpuCanvas, run\n",
+    "import pygfx as gfx\n",
+    "import subprocess\n",
+    "\n",
+    "canvas = WgpuCanvas()\n",
+    "renderer = gfx.WgpuRenderer(canvas)\n",
+    "scene = gfx.Scene()\n",
+    "camera = gfx.OrthographicCamera(5000, 5000)\n",
+    "camera.position.x = 2048\n",
+    "camera.position.y = 2048\n",
+    "\n",
+    "\n",
+    "def make_image():\n",
+    "    data = np.random.rand(4096, 4096).astype(np.float32)\n",
+    "\n",
+    "    return gfx.Image(\n",
+    "        gfx.Geometry(grid=gfx.Texture(data, dim=2)),\n",
+    "        gfx.ImageBasicMaterial(clim=(0, 1)),\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3ec10f26-6544-4ad3-80c1-aa34617dc826",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import weakref"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "acc819a3-cd50-4fdd-a0b5-c442d80847e2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "img = make_image()\n",
+    "img_ref = weakref.ref(img)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f89da335-3372-486b-b773-9f103d6a9bbd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "img_ref()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c22904ad-d674-43e6-83bb-7a2f7b277c06",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "del img"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "573566d7-eb91-4690-958c-d00dd495b3e4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import gc"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "aaef3e89-2bfd-43af-9b8f-824a3f89b85f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "img_ref()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3380f35e-fcc9-43f6-80d2-7e9348cd13b4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "draw()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a27bf7c7-f3ef-4ae8-8ecf-31507f8c0449",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\n",
+    "        subprocess.check_output([\"nvidia-smi\", \"--format=csv\", \"--query-gpu=memory.used\"]).decode().split(\"\\n\")[1]\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e4bf2711-8a83-4d9c-a4f7-f50de7ae1715",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/fastplotlib/graphics/_base.py
+++ b/fastplotlib/graphics/_base.py
@@ -232,8 +232,13 @@ class Interaction(ABC):
 
                     # for now we only have line collections so this works
                     else:
-                        for i, item in enumerate(self._graphics):
-                            if item.world_object is event.pick_info["world_object"]:
+                        # get index of world object that made this event
+                        for i, item in enumerate(self.graphics):
+                            wo = WORLD_OBJECTS[item.loc]
+                            # we only store hex id of worldobject, but worldobject `pick_info` is always the real object
+                            # so if pygfx worldobject triggers an event by itself, such as `click`, etc., this will be
+                            # the real world object in the pick_info and not the proxy
+                            if wo is event.pick_info["world_object"]:
                                 indices = i
                     target_info.target._set_feature(feature=target_info.feature, new_data=target_info.new_data, indices=indices)
                 else:

--- a/fastplotlib/graphics/_base.py
+++ b/fastplotlib/graphics/_base.py
@@ -315,7 +315,7 @@ class GraphicCollection(Graphic):
 
     def remove_graphic(self, graphic: Graphic, reset_index: True):
         """Remove a graphic from the collection"""
-        self._graphics.remove(graphic)
+        self._graphics.remove(graphic.loc)
 
         if reset_index:
             self._reset_index()
@@ -341,7 +341,7 @@ class GraphicCollection(Graphic):
         if isinstance(key, slice):
             key = cleanup_slice(key, upper_bound=len(self))
             selection_indices = range(key.start, key.stop, key.step)
-            selection = self._graphics[key]
+            selection = self.graphics[key]
 
         # fancy-ish indexing
         elif isinstance(key, (tuple, list, np.ndarray)):
@@ -353,7 +353,7 @@ class GraphicCollection(Graphic):
             selection = list()
 
             for ix in key:
-                selection.append(self._graphics[ix])
+                selection.append(self.graphics[ix])
 
             selection_indices = key
         else:

--- a/fastplotlib/graphics/features/_base.py
+++ b/fastplotlib/graphics/features/_base.py
@@ -2,6 +2,7 @@ from abc import ABC, abstractmethod
 from inspect import getfullargspec
 from warnings import warn
 from typing import *
+import weakref
 
 import numpy as np
 from pygfx import Buffer, Texture
@@ -71,7 +72,7 @@ class GraphicFeature(ABC):
             if part of a collection, index of this graphic within the collection
 
         """
-        self._parent = parent
+        self._parent = weakref.proxy(parent)
 
         self._data = to_gpu_supported_dtype(data)
 

--- a/fastplotlib/graphics/image.py
+++ b/fastplotlib/graphics/image.py
@@ -274,7 +274,8 @@ class HeatmapGraphic(Graphic, Interaction):
         start_ixs = [list(map(lambda c: c * chunk_size, chunk)) for chunk in chunks]
         stop_ixs = [list(map(lambda c: c + chunk_size, chunk)) for chunk in start_ixs]
 
-        self._world_object = pygfx.Group()
+        world_object = pygfx.Group()
+        self._set_world_object(world_object)
 
         if (vmin is None) or (vmax is None):
             vmin, vmax = quick_min_max(data)

--- a/fastplotlib/graphics/image.py
+++ b/fastplotlib/graphics/image.py
@@ -100,10 +100,12 @@ class ImageGraphic(Graphic, Interaction):
             self.cmap = ImageCmapFeature(self, cmap)
             material = pygfx.ImageBasicMaterial(clim=(vmin, vmax), map=self.cmap())
 
-        self._world_object: pygfx.Image = pygfx.Image(
+        world_object = pygfx.Image(
             geometry,
             material
         )
+
+        self._set_world_object(world_object)
 
         self.data = ImageDataFeature(self, data)
         # TODO: we need to organize and do this better

--- a/fastplotlib/graphics/line.py
+++ b/fastplotlib/graphics/line.py
@@ -85,11 +85,13 @@ class LineGraphic(Graphic, Interaction):
 
         self.thickness = ThicknessFeature(self, thickness)
 
-        self._world_object: pygfx.Line = pygfx.Line(
+        world_object: pygfx.Line = pygfx.Line(
             # self.data.feature_data because data is a Buffer
             geometry=pygfx.Geometry(positions=self.data(), colors=self.colors()),
             material=material(thickness=self.thickness(), vertex_colors=True)
         )
+
+        self._set_world_object(world_object)
 
         if z_position is not None:
             self.world_object.position.z = z_position

--- a/fastplotlib/graphics/line_collection.py
+++ b/fastplotlib/graphics/line_collection.py
@@ -343,6 +343,6 @@ class LineStack(LineCollection):
         )
 
         axis_zero = 0
-        for i, line in enumerate(self._graphics):
+        for i, line in enumerate(self.graphics):
             getattr(line.position, f"set_{separation_axis}")(axis_zero)
             axis_zero = axis_zero + line.data()[:, axes[separation_axis]].max() + separation

--- a/fastplotlib/graphics/line_collection.py
+++ b/fastplotlib/graphics/line_collection.py
@@ -157,7 +157,7 @@ class LineCollection(GraphicCollection, Interaction):
                         "or must be a str of tuple/list with the same length as the data"
                     )
 
-        self._world_object = pygfx.Group()
+        self._set_world_object(pygfx.Group())
 
         for i, d in enumerate(data):
             if isinstance(z_position, list):

--- a/fastplotlib/graphics/line_slider.py
+++ b/fastplotlib/graphics/line_slider.py
@@ -74,7 +74,7 @@ class LineSlider(Graphic):
         else:
             material = pygfx.LineMaterial
 
-        colors_inner = np.repeat([Color("w")], 2, axis=0).astype(np.float32)
+        colors_inner = np.repeat([Color(color)], 2, axis=0).astype(np.float32)
         colors_outer = np.repeat([Color([1., 1., 1., 0.25])], 2, axis=0).astype(np.float32)
 
         line_inner = pygfx.Line(
@@ -88,17 +88,19 @@ class LineSlider(Graphic):
             material=material(thickness=thickness + 4, vertex_colors=True)
         )
 
-        self._world_object = pygfx.Group()
+        world_object = pygfx.Group()
 
-        self._world_object.add(line_outer)
-        self._world_object.add(line_inner)
+        world_object.add(line_outer)
+        world_object.add(line_inner)
+
+        self._set_world_object(world_object)
 
         self.position.x = x_pos
 
         self.slider = slider
         self.slider.observe(self.set_position, "value")
 
-        self.name = name
+        super().__init__(name=name)
 
     def set_position(self, change):
         self.position.x = change["new"]

--- a/fastplotlib/graphics/scatter.py
+++ b/fastplotlib/graphics/scatter.py
@@ -72,9 +72,11 @@ class ScatterGraphic(Graphic):
 
         super(ScatterGraphic, self).__init__(*args, **kwargs)
 
-        self._world_object: pygfx.Points = pygfx.Points(
+        world_object = pygfx.Points(
             pygfx.Geometry(positions=self.data(), sizes=sizes, colors=self.colors()),
             material=pygfx.PointsMaterial(vertex_colors=True, vertex_sizes=True)
         )
+
+        self._set_world_object(world_object)
 
         self.world_object.position.z = z_position

--- a/fastplotlib/graphics/text.py
+++ b/fastplotlib/graphics/text.py
@@ -38,10 +38,12 @@ class TextGraphic(Graphic):
         """
         super(TextGraphic, self).__init__(name=name)
 
-        self._world_object = pygfx.Text(
+        world_object = pygfx.Text(
             pygfx.TextGeometry(text=text, font_size=size, screen_space=False),
             pygfx.TextMaterial(color=face_color, outline_color=outline_color, outline_thickness=outline_thickness)
         )
+
+        self._set_world_object(world_object)
 
         self.world_object.position.set(*position)
 

--- a/fastplotlib/layouts/_base.py
+++ b/fastplotlib/layouts/_base.py
@@ -3,7 +3,7 @@ from pygfx import Scene, OrthographicCamera, PerspectiveCamera, PanZoomControlle
     Viewport, WgpuRenderer
 from wgpu.gui.auto import WgpuCanvas
 from warnings import warn
-from ..graphics._base import Graphic, WORLD_OBJECTS
+from ..graphics._base import Graphic, GraphicCollection, WORLD_OBJECTS
 from ..graphics.line_slider import LineSlider
 from typing import *
 
@@ -319,8 +319,18 @@ class PlotArea:
 
         self._graphics.remove(graphic)
 
-        # delete associated world object to free GPU VRAM
+        # for GraphicCollection objects
+        if isinstance(graphic, GraphicCollection):
+            # clear Group
+            graphic.world_object.clear()
+            # delete all child world objects in the collection
+            for g in graphic.graphics:
+                subloc = hex(id(g))
+                del WORLD_OBJECTS[subloc]
+
+        # get mem location of graphic
         loc = hex(id(graphic))
+        # delete world object
         del WORLD_OBJECTS[loc]
 
         del graphic

--- a/fastplotlib/layouts/_base.py
+++ b/fastplotlib/layouts/_base.py
@@ -186,14 +186,13 @@ class PlotArea:
         if graphic.name is not None:  # skip for those that have no name
             self._check_graphic_name_exists(graphic.name)
 
-        # store in GRAPHICS dict
-        loc = graphic.loc
-        GRAPHICS[loc] = graphic
-
         # TODO: need to refactor LineSlider entirely
         if isinstance(graphic, LineSlider):
             self._sliders.append(graphic)  # don't manage garbage collection of LineSliders for now
         else:
+            # store in GRAPHICS dict
+            loc = graphic.loc
+            GRAPHICS[loc] = graphic
             self._graphics.append(loc)  # add hex id string for referencing this graphic instance
 
         # add world object to scene

--- a/fastplotlib/layouts/_subplot.py
+++ b/fastplotlib/layouts/_subplot.py
@@ -2,6 +2,7 @@ from typing import *
 import numpy as np
 from math import copysign
 from functools import partial
+import weakref
 from inspect import signature, getfullargspec
 from warnings import warn
 
@@ -112,7 +113,7 @@ class Subplot(PlotArea):
         if self.name is not None:
             self.set_title(self.name)
 
-    def _create_graphic(self, graphic_class, *args, **kwargs):
+    def _create_graphic(self, graphic_class, *args, **kwargs) -> weakref.proxy:
         if "center" in kwargs.keys():
             center = kwargs.pop("center")
         else:
@@ -124,7 +125,8 @@ class Subplot(PlotArea):
         graphic = graphic_class(*args, **kwargs)
         self.add_graphic(graphic, center=center)
 
-        return graphic
+        # only return a proxy to the real graphic
+        return weakref.proxy(graphic)
 
     def set_title(self, text: Any):
         """Sets the name of a subplot to 'top' viewport if defined."""


### PR DESCRIPTION
Follows up from #159 

This implements:

- A global `WORLD_OBJECTS` dict in `fastplotlib.graphics._base` used internally by `fastplotlib` to keep track of all pygfx `WorldObject` instances in a session. `Graphic` instances only use a weak reference proxy to access their `WorldObject` using their hex id. All references to world objects outside of this dict are via proxies.
- A global `GRAPHICS` dict in `fastplotlib.layouts._base` to keep track of all `Graphic` objects, functions similar to the global world objects dict. All references to Graphic objects outside of this dict are via proxies. The various `plot.add_<graphic>` methods only return proxies.

Adds a `PlotArea.delete_graphic()` method which is the only way that a `Graphic` should be deleted. This also frees up GPU VRAM.

GPU VRAM freed and tested for:
- [x] Image
- [x] Line
- [x] LineCollection
- [x] Scatter
- ~[ ] Text~ will do this later once text is more stabilized
- [x] Heatmap (new one)

- [x] Modify how `LineSlider is added in `PlotArea` but don't need to check garbage collection since their memory footprint is very small. UPDATE: This isn't necessary, `LineSlider` continues to work.

RAM freed and tested for:
- [x] Image
- [x] Line
- [x] LineCollection
- [x] Scatter
- [x] Heatmap (new one)

