### PR TITLE
fixes to set_data()

### DIFF
--- a/fastplotlib/widgets/image.py
+++ b/fastplotlib/widgets/image.py
@@ -856,7 +856,7 @@ class ImageWidget:
 
                 self.vmin_vmax_sliders[i].set_state(state)
             else:
-                ig.min, ig.max = mm
+                ig.min, ig.max = mm[0]
 
     def set_data(
             self,

--- a/fastplotlib/widgets/image.py
+++ b/fastplotlib/widgets/image.py
@@ -856,7 +856,7 @@ class ImageWidget:
 
                 self.vmin_vmax_sliders[i].set_state(state)
             else:
-                ig.min, ig.max = mm[0]
+                ig.vmin, ig.vmax = mm[0]
 
     def set_data(
             self,


### PR DESCRIPTION
changes needed in order for `set_data()` to work when a `Plot` instance underlies an `ImageWidget` but a `list()` of length 1 is passed as new data...problem will be solved when `ImageWidget` is refactored to only have underlying `GridpPlot` instead of `Union[Plot, GridPlot]`