### PR TITLE
add canvas kwarg that takes str

### DIFF
--- a/fastplotlib/layouts/_subplot.py
+++ b/fastplotlib/layouts/_subplot.py
@@ -27,7 +27,7 @@ except ImportError:
 try:
     from wgpu.gui.glfw import GlfwWgpuCanvas
 except ImportError:
-    QWgpuCanvas = False
+    GlfwWgpuCanvas = False
 
 
 CANVAS_OPTIONS = ["jupyter", "glfw", "qt"]


### PR DESCRIPTION
allows forcing a canvas with just a str kwarg:

```python
import fastplotlib as fpl
plot = fpl.Plot(canvas="glfw")

data = np.random.rand(512, 512)

image_graphic = plot.add_image(data=data, name="random-image")

plot.show()
```

@EricThomson
