### PR TITLE
maintain aspect handling in gridplot, better canvas renderer args handling in gridplot

### DIFF
--- a/fastplotlib/layouts/_subplot.py
+++ b/fastplotlib/layouts/_subplot.py
@@ -10,7 +10,6 @@ import traceback
 from pygfx import Scene, OrthographicCamera, PanZoomController, OrbitController, \
     AxesHelper, GridHelper, WgpuRenderer, Texture
 from wgpu.gui.auto import WgpuCanvas
-from wgpu.gui.base import WgpuCanvasBase
 
 
 # TODO: this determination can be better
@@ -37,6 +36,7 @@ CANVAS_OPTIONS_AVAILABLE = {
     "qt": QWgpuCanvas
 }
 
+from ._utils import make_canvas_and_renderer
 from ._base import PlotArea
 from .. import graphics
 from ..graphics import TextGraphic
@@ -80,29 +80,8 @@ class Subplot(PlotArea):
         name: str, optional
             name of the subplot, will appear as ``TextGraphic`` above the subplot
         """
-        if canvas is None:
-            canvas = WgpuCanvas()
 
-        elif isinstance(canvas, str):
-            if canvas not in CANVAS_OPTIONS:
-                raise ValueError(
-                    f"str canvas argument must be one of: {CANVAS_OPTIONS}"
-                )
-            elif not CANVAS_OPTIONS_AVAILABLE[canvas]:
-                raise ImportError(
-                    f"The {canvas} framework is not installed for using this canvas"
-                )
-            else:
-                canvas = CANVAS_OPTIONS_AVAILABLE[canvas]()
-
-        elif not isinstance(canvas, (WgpuCanvasBase, Texture)):
-            raise ValueError(
-                f"canvas option must either be a valid WgpuCanvas implementation, a pygfx Texture"
-                f" or a str from the following options: {CANVAS_OPTIONS}"
-            )
-
-        if renderer is None:
-            renderer = WgpuRenderer(canvas)
+        canvas, renderer = make_canvas_and_renderer(canvas, renderer)
 
         if position is None:
             position = (0, 0)

--- a/fastplotlib/layouts/_utils.py
+++ b/fastplotlib/layouts/_utils.py
@@ -1,0 +1,72 @@
+from typing import *
+
+from pygfx import WgpuRenderer, Texture
+
+# default auto-determined canvas
+from wgpu.gui.auto import WgpuCanvas
+from wgpu.gui.base import WgpuCanvasBase
+
+
+# TODO: this determination can be better
+try:
+    from wgpu.gui.jupyter import JupyterWgpuCanvas
+except ImportError:
+    JupyterWgpuCanvas = False
+
+try:
+    from wgpu.gui.qt import QWgpuCanvas
+except ImportError:
+    QWgpuCanvas = False
+
+try:
+    from wgpu.gui.glfw import GlfwWgpuCanvas
+except ImportError:
+    GlfwWgpuCanvas = False
+
+
+CANVAS_OPTIONS = ["jupyter", "glfw", "qt"]
+CANVAS_OPTIONS_AVAILABLE = {
+    "jupyter": JupyterWgpuCanvas,
+    "glfw": GlfwWgpuCanvas,
+    "qt": QWgpuCanvas
+}
+
+
+def make_canvas_and_renderer(
+        canvas: Union[str, WgpuCanvas, Texture, None],
+        renderer: [WgpuRenderer, None]
+) -> Tuple[Union[JupyterWgpuCanvas, GlfwWgpuCanvas, QWgpuCanvas], WgpuRenderer]:
+    """
+    Parses arguments and returns the appropriate canvas and renderer instances
+
+    Returns
+    -------
+    Tuple[JupyterWgpuCanvas | GlfwWgpuCanvas| QWgpuCanvas, WgpuRenderer]
+        a usable canvas and renderer instance
+    """
+
+    if canvas is None:
+        canvas = WgpuCanvas()
+
+    elif isinstance(canvas, str):
+        if canvas not in CANVAS_OPTIONS:
+            raise ValueError(
+                f"str canvas argument must be one of: {CANVAS_OPTIONS}"
+            )
+        elif not CANVAS_OPTIONS_AVAILABLE[canvas]:
+            raise ImportError(
+                f"The {canvas} framework is not installed for using this canvas"
+            )
+        else:
+            canvas = CANVAS_OPTIONS_AVAILABLE[canvas]()
+
+    elif not isinstance(canvas, (WgpuCanvasBase, Texture)):
+        raise ValueError(
+            f"canvas option must either be a valid WgpuCanvas implementation, a pygfx Texture"
+            f" or a str from the following options: {CANVAS_OPTIONS}"
+        )
+
+    if renderer is None:
+        renderer = WgpuRenderer(canvas)
+
+    return canvas, renderer

--- a/fastplotlib/layouts/_utils.py
+++ b/fastplotlib/layouts/_utils.py
@@ -35,14 +35,10 @@ CANVAS_OPTIONS_AVAILABLE = {
 def make_canvas_and_renderer(
         canvas: Union[str, WgpuCanvas, Texture, None],
         renderer: [WgpuRenderer, None]
-) -> Tuple[Union[JupyterWgpuCanvas, GlfwWgpuCanvas, QWgpuCanvas], WgpuRenderer]:
+):
     """
-    Parses arguments and returns the appropriate canvas and renderer instances
-
-    Returns
-    -------
-    Tuple[JupyterWgpuCanvas | GlfwWgpuCanvas| QWgpuCanvas, WgpuRenderer]
-        a usable canvas and renderer instance
+    Parses arguments and returns the appropriate canvas and renderer instances 
+    as a tuple (canvas, renderer)
     """
 
     if canvas is None:


### PR DESCRIPTION
- maintain_aspect behavior in `GridPlot` is such that it will use the `camera.main_aspect` value by default for each subplot if `show(matain_apsect=None)`. Otherwises uses the kwarg value
- move canvas parsing to `layouts/_utils.py`, and canvas str args now works for `GridPlot`, #233 really only worked only for `Plot`
